### PR TITLE
Various fixes on LUKE tokenizer and model

### DIFF
--- a/src/transformers/models/luke/configuration_luke.py
+++ b/src/transformers/models/luke/configuration_luke.py
@@ -43,8 +43,9 @@ class LukeConfig(RobertaConfig):
         entity_emb_size (:obj:`int`, `optional`, defaults to 256):
             The number of dimensions of the entity embedding.
         use_entity_aware_attention (:obj:`bool`, defaults to :obj:`True`):
-            Whether or not the model should use entity-aware self-attention mechanism proposed in the original paper
-            <https://arxiv.org/abs/2010.01057>.
+            Whether or not the model should use the entity-aware self-attention mechanism proposed in
+            `LUKE: Deep Contextualized Entity Representations with Entity-aware Self-attention (Yamada et al.)
+            <https://arxiv.org/abs/2010.01057>`__.
 
     Examples::
         >>> from transformers import LukeConfig, LukeModel

--- a/src/transformers/models/luke/modeling_luke.py
+++ b/src/transformers/models/luke/modeling_luke.py
@@ -62,8 +62,7 @@ class BaseLukeModelOutputWithPooling(BaseModelOutputWithPooling):
             Sequence of entity hidden-states at the output of the last layer of the model.
         pooler_output (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, hidden_size)`):
             Last layer hidden-state of the first token of the sequence (classification token) further processed by a
-            Linear layer and a Tanh activation function. The Linear layer weights are trained from the next sentence
-            prediction (classification) objective during pretraining.
+            Linear layer and a Tanh activation function.
         hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, sequence_length, hidden_size)`. Hidden-states of the model at the output of
@@ -71,7 +70,7 @@ class BaseLukeModelOutputWithPooling(BaseModelOutputWithPooling):
         entity_hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, entity_length, hidden_size)`. Entity hidden-states of the model at the output
-            of each layer plus the initial embedding outputs.
+            of each layer plus the initial entity embedding outputs.
         attentions (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
             Tuple of :obj:`torch.FloatTensor` (one for each layer) of shape :obj:`(batch_size, num_heads,
             sequence_length + entity_length, sequence_length + entity_length)`. Attentions weights after the attention
@@ -102,7 +101,7 @@ class BaseLukeModelOutput(BaseModelOutput):
         entity_hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, entity_length, hidden_size)`. Entity hidden-states of the model at the output
-            of each layer plus the initial embedding outputs.
+            of each layer plus the initial entity embedding outputs.
         attentions (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
             Tuple of :obj:`torch.FloatTensor` (one for each layer) of shape :obj:`(batch_size, num_heads,
             sequence_length, sequence_length)`.
@@ -134,7 +133,7 @@ class EntityClassificationOutput(ModelOutput):
         entity_hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, entity_length, hidden_size)`. Entity hidden-states of the model at the output
-            of each layer plus the initial embedding outputs.
+            of each layer plus the initial entity embedding outputs.
         attentions (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
             Tuple of :obj:`torch.FloatTensor` (one for each layer) of shape :obj:`(batch_size, num_heads,
             sequence_length, sequence_length)`. Attentions weights after the attention softmax, used to compute the
@@ -167,7 +166,7 @@ class EntityPairClassificationOutput(ModelOutput):
         entity_hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, entity_length, hidden_size)`. Entity hidden-states of the model at the output
-            of each layer plus the initial embedding outputs.
+            of each layer plus the initial entity embedding outputs.
         attentions (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
             Tuple of :obj:`torch.FloatTensor` (one for each layer) of shape :obj:`(batch_size, num_heads,
             sequence_length, sequence_length)`. Attentions weights after the attention softmax, used to compute the
@@ -200,7 +199,7 @@ class EntitySpanClassificationOutput(ModelOutput):
         entity_hidden_states (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
             Tuple of :obj:`torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer)
             of shape :obj:`(batch_size, entity_length, hidden_size)`. Entity hidden-states of the model at the output
-            of each layer plus the initial embedding outputs.
+            of each layer plus the initial entity embedding outputs.
         attentions (:obj:`tuple(torch.FloatTensor)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
             Tuple of :obj:`torch.FloatTensor` (one for each layer) of shape :obj:`(batch_size, num_heads,
             sequence_length, sequence_length)`. Attentions weights after the attention softmax, used to compute the
@@ -774,14 +773,14 @@ LUKE_INPUTS_DOCSTRING = r"""
 
             `What are position IDs? <../glossary.html#position-ids>`_
 
-        entity_ids (:obj:`torch.LongTensor` of shape :obj:`({0})`):
+        entity_ids (:obj:`torch.LongTensor` of shape :obj:`(batch_size, entity_length)`):
             Indices of entity tokens in the entity vocabulary.
 
             Indices can be obtained using :class:`~transformers.LukeTokenizer`. See
             :meth:`transformers.PreTrainedTokenizer.encode` and :meth:`transformers.PreTrainedTokenizer.__call__` for
             details.
 
-        entity_attention_mask (:obj:`torch.FloatTensor` of shape :obj:`({0})`, `optional`):
+        entity_attention_mask (:obj:`torch.FloatTensor` of shape :obj:`(batch_size, entity_length)`, `optional`):
             Mask to avoid performing attention on padding entity token indices. Mask values selected in ``[0, 1]``:
 
 
@@ -789,7 +788,7 @@ LUKE_INPUTS_DOCSTRING = r"""
             - 1 for entity tokens that are **not masked**,
             - 0 for entity tokens that are **masked**.
 
-        entity_token_type_ids (:obj:`torch.LongTensor` of shape :obj:`({0})`, `optional`):
+        entity_token_type_ids (:obj:`torch.LongTensor` of shape :obj:`(batch_size, entity_length)`, `optional`):
             Segment token indices to indicate first and second portions of the entity token inputs. Indices are
             selected in ``[0, 1]``:
 
@@ -891,23 +890,23 @@ class LukeModel(LukePreTrainedModel):
 
             >>> from transformers import LukeTokenizer, LukeModel
 
-            >>> tokenizer = LukeTokenizer.from_pretrained('studio-ousia/luke-base')
-            >>> model = LukeModel.from_pretrained('studio-ousia/luke-base')
+            >>> tokenizer = LukeTokenizer.from_pretrained("studio-ousia/luke-base")
+            >>> model = LukeModel.from_pretrained("studio-ousia/luke-base")
 
-            # Compute the contextualized entity representation for "Beyoncé" from the <mask> entity token.
+            # Compute the contextualized entity representation corresponding to the entity mention "Beyoncé" using the [MASK] entity token.
             >>> text = "Beyoncé lives in New York."
-            >>> entities = ["<mask>"]
-            >>> entity_spans = [(0, 7)]
+            >>> entities = ["[MASK]"]
+            >>> entity_spans = [(0, 7)]  # character-based entity span corresponding to "Beyoncé"
 
             >>> encoding = tokenizer(text, entities=entities, entity_spans=entity_spans, add_prefix_space=True, return_tensors="pt")
             >>> outputs = model(**encoding)
             >>> word_last_hidden_state = outputs.word_last_hidden_state
             >>> entity_last_hidden_state = outputs.entity_last_hidden_state
 
-            # Input Wikipedia entities to enrich the contextualized representation.
+            # Input Wikipedia entities to obtain enriched contextualized representations.
             >>> text = "Beyoncé lives in New York."
-            >>> entities = ["Beyoncé", "New York City"]
-            >>> entity_spans = [(0, 7), (17, 25)]
+            >>> entities = ["Beyoncé", "New York City"]  # Wikipedia entity titles corresponding to the entity mentions "Beyoncé" and "New York"
+            >>> entity_spans = [(0, 7), (17, 25)]  # character-based entity spans corresponding to "Beyoncé" and "New York"
 
             >>> encoding = tokenizer(text, entities=entities, entity_spans=entity_spans, add_prefix_space=True, return_tensors="pt")
             >>> outputs = model(**encoding)
@@ -1037,7 +1036,7 @@ def create_position_ids_from_input_ids(input_ids, padding_idx):
 
 @add_start_docstrings(
     """
-    The LUKE model with a classification head on top (a linear layer on top of the hidden state of the <mask> entity
+    The LUKE model with a classification head on top (a linear layer on top of the hidden state of the first entity
     token) for entity classification tasks, such as Open Entity.
     """,
     LUKE_START_DOCSTRING,
@@ -1087,11 +1086,11 @@ class LukeForEntityClassification(LukePreTrainedModel):
 
             >>> from transformers import LukeTokenizer, LukeForEntityClassification
 
-            >>> tokenizer = LukeTokenizer.from_pretrained('studio-ousia/luke-base', task="entity_classification")
-            >>> model = LukeForEntityClassification.from_pretrained('studio-ousia/luke-base')
+            >>> tokenizer = LukeTokenizer.from_pretrained("studio-ousia/luke-base", task="entity_classification")
+            >>> model = LukeForEntityClassification.from_pretrained("studio-ousia/luke-base")
 
             >>> text = "Beyoncé lives in New York."
-            >>> entity_spans = [(0, 7)]
+            >>> entity_spans = [(0, 7)]  # character-based entity span corresponding to "Beyoncé"
             >>> inputs = tokenizer(text, entity_spans=entity_spans, task="entity_classification", return_tensors="pt")
             >>> outputs = model(**inputs)
             >>> logits = outputs.logits
@@ -1145,8 +1144,8 @@ class LukeForEntityClassification(LukePreTrainedModel):
 
 @add_start_docstrings(
     """
-    The LUKE Model with a classification head on top (a linear layer on top of the hidden states of the two <mask>
-    entity tokens) for entity pair classification tasks, such as TACRED.
+    The LUKE Model with a classification head on top (a linear layer on top of the hidden states of the two entity
+    tokens) for entity pair classification tasks, such as TACRED.
     """,
     LUKE_START_DOCSTRING,
 )
@@ -1196,7 +1195,7 @@ class LukeForEntityPairClassification(LukePreTrainedModel):
             >>> from transformers import LukeTokenizer, LukeForEntityPairClassification
 
             >>> text = "Beyoncé lives in New York."
-            >>> entity_spans = [(0, 7), (17, 25)]
+            >>> entity_spans = [(0, 7), (17, 25)]  # character-based entity spans corresponding to "Beyoncé" and "New York"
             >>> inputs = tokenizer(text, entity_spans=entity_spans, task="entity_pair_classification", return_tensors="pt")
             >>> outputs = model(**inputs)
             >>> logits = outputs.logits
@@ -1309,12 +1308,12 @@ class LukeForEntitySpanClassification(LukePreTrainedModel):
 
             >>> from transformers import LukeTokenizer, LukeForEntitySpanClassification
 
-            >>> tokenizer = LukeTokenizer.from_pretrained('studio-ousia/luke-base')
-            >>> model = LukeForEntitySpanClassification.from_pretrained('studio-ousia/luke-base')
+            >>> tokenizer = LukeTokenizer.from_pretrained("studio-ousia/luke-base")
+            >>> model = LukeForEntitySpanClassification.from_pretrained("studio-ousia/luke-base")
 
             >>> text = "Beyoncé lives in New York."
-            >>> entities = ["<mask>", "<mask>"]
-            >>> entity_spans = [(0, 7), (17, 25)]
+            >>> entities = ["[MASK]", "[MASK]"]
+            >>> entity_spans = [(0, 7), (17, 25)]  # character-based entity spans corresponding to "Beyoncé" and "New York"
             >>> inputs = tokenizer(text, entities=entities, entity_spans=entity_spans, return_tensors="pt")
             >>> outputs = model(**inputs)
             >>> logits = outputs.logits

--- a/src/transformers/models/luke/modeling_luke.py
+++ b/src/transformers/models/luke/modeling_luke.py
@@ -893,12 +893,11 @@ class LukeModel(LukePreTrainedModel):
             >>> tokenizer = LukeTokenizer.from_pretrained("studio-ousia/luke-base")
             >>> model = LukeModel.from_pretrained("studio-ousia/luke-base")
 
-            # Compute the contextualized entity representation corresponding to the entity mention "Beyoncé" using the [MASK] entity token.
+            # Compute the contextualized entity representation corresponding to the entity mention "Beyoncé"
             >>> text = "Beyoncé lives in New York."
-            >>> entities = ["[MASK]"]
             >>> entity_spans = [(0, 7)]  # character-based entity span corresponding to "Beyoncé"
 
-            >>> encoding = tokenizer(text, entities=entities, entity_spans=entity_spans, add_prefix_space=True, return_tensors="pt")
+            >>> encoding = tokenizer(text, entity_spans=entity_spans, add_prefix_space=True, return_tensors="pt")
             >>> outputs = model(**encoding)
             >>> word_last_hidden_state = outputs.word_last_hidden_state
             >>> entity_last_hidden_state = outputs.entity_last_hidden_state
@@ -1312,9 +1311,8 @@ class LukeForEntitySpanClassification(LukePreTrainedModel):
             >>> model = LukeForEntitySpanClassification.from_pretrained("studio-ousia/luke-base")
 
             >>> text = "Beyoncé lives in New York."
-            >>> entities = ["[MASK]", "[MASK]"]
             >>> entity_spans = [(0, 7), (17, 25)]  # character-based entity spans corresponding to "Beyoncé" and "New York"
-            >>> inputs = tokenizer(text, entities=entities, entity_spans=entity_spans, return_tensors="pt")
+            >>> inputs = tokenizer(text, entity_spans=entity_spans, return_tensors="pt")
             >>> outputs = model(**inputs)
             >>> logits = outputs.logits
         """

--- a/src/transformers/models/luke/modeling_luke.py
+++ b/src/transformers/models/luke/modeling_luke.py
@@ -701,18 +701,21 @@ class LukePreTrainedModel(PreTrainedModel):
     base_model_prefix = "luke"
 
     def _init_weights(self, module: nn.Module):
+        """ Initialize the weights """
         if isinstance(module, nn.Linear):
             module.weight.data.normal_(mean=0.0, std=self.config.initializer_range)
+            if module.bias is not None:
+                module.bias.data.zero_()
         elif isinstance(module, nn.Embedding):
             if module.embedding_dim == 1:  # embedding for bias parameters
                 module.weight.data.zero_()
             else:
                 module.weight.data.normal_(mean=0.0, std=self.config.initializer_range)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
         elif isinstance(module, nn.LayerNorm):
             module.bias.data.zero_()
             module.weight.data.fill_(1.0)
-        if isinstance(module, nn.Linear) and module.bias is not None:
-            module.bias.data.zero_()
 
 
 LUKE_START_DOCSTRING = r"""

--- a/src/transformers/models/luke/tokenization_luke.py
+++ b/src/transformers/models/luke/tokenization_luke.py
@@ -87,8 +87,8 @@ class LukeTokenizer(RobertaTokenizer):
         entity_vocab_file (:obj:`str`):
             Path to the entity vocabulary file.
         task (:obj:`str`, `optional`):
-            Task for which you want to prepare sequences. One of 'entity_classification' or
-            'entity_pair_classification'. If you specify this argument, the entity sequence is automatically created
+            Task for which you want to prepare sequences. One of "entity_classification" or
+            "entity_pair_classification". If you specify this argument, the entity sequence is automatically created
             based on the given entity spans.
         max_entity_length (:obj:`int`, `optional`, defaults to 32):
             The maximum length of :obj:`entity_ids`.
@@ -96,10 +96,10 @@ class LukeTokenizer(RobertaTokenizer):
             The maximum number of tokens inside an entity span.
         entity_token_1 (:obj:`str`, `optional`, defaults to :obj:`<ent>`):
             The special token representing an entity span. This token is only used when `task` is set to
-            `entity_classification` or `entity_pair_classification`.
+            "entity_classification" or "entity_pair_classification".
         entity_token_2 (:obj:`str`, `optional`, defaults to :obj:`<ent2>`):
             The special token representing an entity span. This token is only used when `task` is set to
-            `entity_pair_classification`.
+            "entity_pair_classification".
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
@@ -165,10 +165,10 @@ class LukeTokenizer(RobertaTokenizer):
         self,
         text: Union[TextInput, List[TextInput]],
         text_pair: Optional[Union[TextInput, List[TextInput]]] = None,
-        entities: Optional[Union[List[str], List[List[str]]]] = None,
-        entities_pair: Optional[Union[List[str], List[List[str]]]] = None,
         entity_spans: Optional[Union[List[Tuple[int, int]], List[List[Tuple[int, int]]]]] = None,
         entity_spans_pair: Optional[Union[List[Tuple[int, int]], List[List[Tuple[int, int]]]]] = None,
+        entities: Optional[Union[List[str], List[List[str]]]] = None,
+        entities_pair: Optional[Union[List[str], List[List[str]]]] = None,
         add_special_tokens: bool = True,
         padding: Union[bool, str, PaddingStrategy] = False,
         truncation: Union[bool, str, TruncationStrategy] = False,
@@ -198,25 +198,31 @@ class LukeTokenizer(RobertaTokenizer):
             text_pair (:obj:`str`, :obj:`List[str]`, :obj:`List[List[str]]`):
                 The sequence or batch of sequences to be encoded. Each sequence must be a string. Note that this
                 tokenizer does not support tokenization based on pretokenized strings.
-            entities (:obj:`List[str]`, :obj:`List[List[str]]`, `optional`):
-                The sequence or batch of sequences of entities to be encoded. Each sequence consists of strings
-                representing entities, i.e., special entities (e.g., [MASK]) or entity titles of Wikipedia (e.g., New
-                York). This argument is ignored if you specify the `task` argument in the constructor.
-            entities_pair (:obj:`List[str]`, :obj:`List[List[str]]`, `optional`):
-                The sequence or batch of sequences of entities to be encoded. Each sequence consists of strings
-                representing entities, i.e., special entities (e.g., [MASK]) or entity titles of Wikipedia (e.g., New
-                York). This argument is ignored if you specify the `task` argument in the constructor.
             entity_spans (:obj:`List[Tuple]`, :obj:`List[List[Tuple]]`, `optional`):
                 The sequence or batch of sequences of entity spans to be encoded. Each sequence consists of tuples each
-                with two integers denoting start and end positions of entities. If you specify `entity_classification`
-                or `entity_pair_classification` as the `task` argument in the constructor, the length of each sequence
+                with two integers denoting start and end positions of entities. If you specify "entity_classification"
+                or "entity_pair_classification" as the `task` argument in the constructor, the length of each sequence
                 must be 1 or 2, respectively. If you specify `entities`, the length of each sequence must be equal to
-                each sequence of `entities`.
+                the length of each sequence of `entities`.
             entity_spans_pair (:obj:`List[Tuple]`, :obj:`List[List[Tuple]]`, `optional`):
                 The sequence or batch of sequences of entity spans to be encoded. Each sequence consists of tuples each
                 with two integers denoting start and end positions of entities. If you specify the `task` argument in
                 the constructor, this argument is ignored. If you specify `entities_pair`, the length of each sequence
-                must be equal to each sequence of `entities_pair`.
+                must be equal to the length of each sequence of `entities_pair`.
+            entities (:obj:`List[str]`, :obj:`List[List[str]]`, `optional`):
+                The sequence or batch of sequences of entities to be encoded. Each sequence consists of strings
+                representing entities, i.e., special entities (e.g., [MASK]) or entity titles of Wikipedia (e.g., New
+                York). This argument is ignored if you specify the `task` argument in the constructor. The length of
+                each sequence must be equal to the length of each sequence of `entity_spans`. If you specify
+                `entity_spans` without specifying this argument, the entity sequence or the batch of entity sequences
+                is automatically constructed by filling it with the [MASK] special entities.
+            entities_pair (:obj:`List[str]`, :obj:`List[List[str]]`, `optional`):
+                The sequence or batch of sequences of entities to be encoded. Each sequence consists of strings
+                representing entities, i.e., special entities (e.g., [MASK]) or entity titles of Wikipedia (e.g., New
+                York). This argument is ignored if you specify the `task` argument in the constructor. The length of
+                each sequence must be equal to the length of each sequence of `entity_spans_pair`. If you specify
+                `entity_spans_pair` without specifying this argument, the entity sequence or the batch of entity
+                sequences is automatically constructed by filling it with the [MASK] special entities.
             max_entity_length (:obj:`int`, `optional`):
                 The maximum length of :obj:`entity_ids`.
         """
@@ -251,8 +257,8 @@ class LukeTokenizer(RobertaTokenizer):
 
             return self.batch_encode_plus(
                 batch_text_or_text_pairs=batch_text_or_text_pairs,
-                batch_entities_or_entities_pairs=batch_entities_or_entities_pairs,
                 batch_entity_spans_or_entity_spans_pairs=batch_entity_spans_or_entity_spans_pairs,
+                batch_entities_or_entities_pairs=batch_entities_or_entities_pairs,
                 add_special_tokens=add_special_tokens,
                 padding=padding,
                 truncation=truncation,
@@ -275,10 +281,10 @@ class LukeTokenizer(RobertaTokenizer):
             return self.encode_plus(
                 text=text,
                 text_pair=text_pair,
-                entities=entities,
-                entities_pair=entities_pair,
                 entity_spans=entity_spans,
                 entity_spans_pair=entity_spans_pair,
+                entities=entities,
+                entities_pair=entities_pair,
                 add_special_tokens=add_special_tokens,
                 padding=padding,
                 truncation=truncation,
@@ -303,10 +309,10 @@ class LukeTokenizer(RobertaTokenizer):
         self,
         text: Union[TextInput],
         text_pair: Optional[Union[TextInput]] = None,
-        entities: Optional[List[str]] = None,
-        entities_pair: Optional[List[str]] = None,
         entity_spans: Optional[List[Tuple[int, int]]] = None,
         entity_spans_pair: Optional[List[Tuple[int, int]]] = None,
+        entities: Optional[List[str]] = None,
+        entities_pair: Optional[List[str]] = None,
         add_special_tokens: bool = True,
         padding: Union[bool, str, PaddingStrategy] = False,
         truncation: Union[bool, str, TruncationStrategy] = False,
@@ -335,29 +341,33 @@ class LukeTokenizer(RobertaTokenizer):
                 The first sequence to be encoded. Each sequence must be a string.
             text_pair (:obj:`str`):
                 The second sequence to be encoded. Each sequence must be a string.
-            entities (:obj:`List[str]` `optional`)::
-                The first sequence of entities to be encoded. The sequence consists of strings representing entities,
-                i.e., special entities (e.g., [MASK]) or entity titles of Wikipedia (e.g., New York). This argument is
-                ignored if you specify the `task` argument in the constructor.
-            entities_pair (:obj:`List[str]`, obj:`List[List[str]]`, `optional`)::
-                The second sequence of entities to be encoded. The sequence consists of strings representing entities,
-                i.e., special entities (e.g., [MASK]) or entity titles of Wikipedia (e.g., New York). This argument is
-                ignored if you specify the `task` argument in the constructor.
             entity_spans (:obj:`List[Tuple]`, obj:`List[List[Tuple]]`, `optional`)::
                 The first sequence of entity spans to be encoded. The sequence consists of tuples each with two
-                integers denoting start and end positions of entities. If you specify `entity_classification` or
-                `entity_pair_classification` as the `task` argument in the constructor, the length of each sequence
+                integers denoting start and end positions of entities. If you specify "entity_classification" or
+                "entity_pair_classification" as the `task` argument in the constructor, the length of each sequence
                 must be 1 or 2, respectively. If you specify `entities`, the length of the sequence must be equal to
-                the sequence of `entities`.
+                the length of `entities`.
             entity_spans_pair (:obj:`List[Tuple]`, obj:`List[List[Tuple]]`, `optional`)::
                 The second sequence of entity spans to be encoded. The sequence consists of tuples each with two
                 integers denoting start and end positions of entities. If you specify the `task` argument in the
                 constructor, this argument is ignored. If you specify `entities_pair`, the length of the sequence must
-                be equal to the sequence of `entities_pair`.
+                be equal to the length of `entities_pair`.
+            entities (:obj:`List[str]` `optional`)::
+                The first sequence of entities to be encoded. The sequence consists of strings representing entities,
+                i.e., special entities (e.g., [MASK]) or entity titles of Wikipedia (e.g., New York). This argument is
+                ignored if you specify the `task` argument in the constructor. The length of the sequence must be equal
+                to the length of `entity_spans`. If you specify `entity_spans` without specifying this argument, the
+                entity sequence is automatically constructed by filling it with the [MASK] special entities.
+            entities_pair (:obj:`List[str]`, obj:`List[List[str]]`, `optional`)::
+                The second sequence of entities to be encoded. The sequence consists of strings representing entities,
+                i.e., special entities (e.g., [MASK]) or entity titles of Wikipedia (e.g., New York). This argument is
+                ignored if you specify the `task` argument in the constructor. The length of the sequence must be equal
+                to the length of `entity_spans_pair`. If you specify `entity_spans_pair` without specifying this
+                argument, the entity sequence is automatically constructed by filling it with the [MASK] special
+                entities.
             max_entity_length (:obj:`int`, `optional`):
                 The maximum length of the entity sequence.
         """
-
         # Backward compatibility for 'truncation_strategy', 'pad_to_max_length'
         padding_strategy, truncation_strategy, max_length, kwargs = self._get_padding_truncation_strategies(
             padding=padding,
@@ -371,10 +381,10 @@ class LukeTokenizer(RobertaTokenizer):
         return self._encode_plus(
             text=text,
             text_pair=text_pair,
-            entities=entities,
-            entities_pair=entities_pair,
             entity_spans=entity_spans,
             entity_spans_pair=entity_spans_pair,
+            entities=entities,
+            entities_pair=entities_pair,
             add_special_tokens=add_special_tokens,
             padding_strategy=padding_strategy,
             truncation_strategy=truncation_strategy,
@@ -398,10 +408,10 @@ class LukeTokenizer(RobertaTokenizer):
         self,
         text: Union[TextInput],
         text_pair: Optional[Union[TextInput]] = None,
-        entities: Optional[List[str]] = None,
-        entities_pair: Optional[List[str]] = None,
         entity_spans: Optional[List[Tuple[int, int]]] = None,
         entity_spans_pair: Optional[List[Tuple[int, int]]] = None,
+        entities: Optional[List[str]] = None,
+        entities_pair: Optional[List[str]] = None,
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
@@ -479,10 +489,10 @@ class LukeTokenizer(RobertaTokenizer):
     def batch_encode_plus(
         self,
         batch_text_or_text_pairs: Union[List[TextInput], List[TextInputPair]],
-        batch_entities_or_entities_pairs: Optional[Union[List[List[str]], List[Tuple[List[str], List[str]]]]] = None,
         batch_entity_spans_or_entity_spans_pairs: Optional[
             Union[List[List[Tuple[int, int]]], List[Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]]]
         ] = None,
+        batch_entities_or_entities_pairs: Optional[Union[List[List[str]], List[Tuple[List[str], List[str]]]]] = None,
         add_special_tokens: bool = True,
         padding: Union[bool, str, PaddingStrategy] = False,
         truncation: Union[bool, str, TruncationStrategy] = False,
@@ -512,13 +522,13 @@ class LukeTokenizer(RobertaTokenizer):
             batch_text_or_text_pairs (:obj:`List[str]`, :obj:`List[Tuple[str, str]]`):
                 Batch of sequences or pair of sequences to be encoded. This can be a list of string or a list of pair
                 of string (see details in ``encode_plus``).
-            batch_entities_or_entities_pairs (:obj:`List[List[str]]`, :obj:`List[Tuple[List[str], List[str]]]`,
-            `optional`):
-                Batch of entity sequences or pairs of entity sequences to be encoded (see details in ``encode_plus``).
             batch_entity_spans_or_entity_spans_pairs (:obj:`List[List[Tuple[int, int]]]`,
             :obj:`List[Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]]`, `optional`)::
                 Batch of entity span sequences or pairs of entity span sequences to be encoded (see details in
                 ``encode_plus``).
+            batch_entities_or_entities_pairs (:obj:`List[List[str]]`, :obj:`List[Tuple[List[str], List[str]]]`,
+            `optional`):
+                Batch of entity sequences or pairs of entity sequences to be encoded (see details in ``encode_plus``).
             max_entity_length (:obj:`int`, `optional`):
                 The maximum length of the entity sequence.
         """
@@ -535,8 +545,8 @@ class LukeTokenizer(RobertaTokenizer):
 
         return self._batch_encode_plus(
             batch_text_or_text_pairs=batch_text_or_text_pairs,
-            batch_entities_or_entities_pairs=batch_entities_or_entities_pairs,
             batch_entity_spans_or_entity_spans_pairs=batch_entity_spans_or_entity_spans_pairs,
+            batch_entities_or_entities_pairs=batch_entities_or_entities_pairs,
             add_special_tokens=add_special_tokens,
             padding_strategy=padding_strategy,
             truncation_strategy=truncation_strategy,
@@ -559,10 +569,10 @@ class LukeTokenizer(RobertaTokenizer):
     def _batch_encode_plus(
         self,
         batch_text_or_text_pairs: Union[List[TextInput], List[TextInputPair]],
-        batch_entities_or_entities_pairs: Optional[Union[List[List[str]], List[Tuple[List[str], List[str]]]]] = None,
         batch_entity_spans_or_entity_spans_pairs: Optional[
             Union[List[List[Tuple[int, int]]], List[Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]]]
         ] = None,
+        batch_entities_or_entities_pairs: Optional[Union[List[List[str]], List[Tuple[List[str], List[str]]]]] = None,
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
@@ -711,29 +721,49 @@ class LukeTokenizer(RobertaTokenizer):
 
         if self.task is None:
             unk_entity_id = self.entity_vocab["[UNK]"]
-            if entities is None:
+            mask_entity_id = self.entity_vocab["[MASK]"]
+
+            if entity_spans is None:
                 first_ids = get_input_ids(text)
-                second_ids = get_input_ids(text_pair) if text_pair is not None else None
             else:
-                assert isinstance(entities, list) and (
-                    len(entities) == 0 or isinstance(entities[0], str)
-                ), "Entities should be given as a list of entity names"
                 assert isinstance(entity_spans, list) and (
                     len(entity_spans) == 0 or isinstance(entity_spans[0], tuple)
-                ), "Entity spans should be given as a list of tuples containing the start and end character indices"
-                assert len(entities) == len(entity_spans), "entities and entity_spans must be the same length"
+                ), "entity_spans should be given as a list of tuples containing the start and end character indices"
+                assert entities is None or (
+                    isinstance(entities, list) and (len(entities) == 0 or isinstance(entities[0], str))
+                ), "If you specify entities, they should be given as a list of entity names"
+                assert entities is None or len(entities) == len(
+                    entity_spans
+                ), "If you specify entities, entities and entity_spans must be the same length"
 
-                first_entity_ids = [self.entity_vocab.get(entity, unk_entity_id) for entity in entities]
                 first_ids, first_entity_token_spans = get_input_ids_and_entity_token_spans(text, entity_spans)
-                if text_pair:
-                    second_entity_ids = (
-                        [self.entity_vocab.get(entity, unk_entity_id) for entity in entities_pair]
-                        if entities_pair is not None
-                        else None
-                    )
+                if entities is None:
+                    first_entity_ids = [mask_entity_id] * len(entity_spans)
+                else:
+                    first_entity_ids = [self.entity_vocab.get(entity, unk_entity_id) for entity in entities]
+
+            if text_pair is not None:
+                if entity_spans_pair is None:
+                    second_ids = get_input_ids(text_pair)
+                else:
+                    assert isinstance(entity_spans_pair, list) and (
+                        len(entity_spans_pair) == 0 or isinstance(entity_spans_pair[0], tuple)
+                    ), "entity_spans_pair should be given as a list of tuples containing the start and end character indices"
+                    assert entities_pair is None or (
+                        isinstance(entities_pair, list)
+                        and (len(entities_pair) == 0 or isinstance(entities_pair[0], str))
+                    ), "If you specify entities_pair, they should be given as a list of entity names"
+                    assert entities_pair is None or len(entities_pair) == len(
+                        entity_spans_pair
+                    ), "If you specify entities_pair, entities_pair and entity_spans_pair must be the same length"
+
                     second_ids, second_entity_token_spans = get_input_ids_and_entity_token_spans(
                         text_pair, entity_spans_pair
                     )
+                    if entities_pair is None:
+                        second_entity_ids = [mask_entity_id] * len(entity_spans_pair)
+                    else:
+                        second_entity_ids = [self.entity_vocab.get(entity, unk_entity_id) for entity in entities_pair]
 
         elif self.task == "entity_classification":
             assert (

--- a/tests/test_tokenization_luke.py
+++ b/tests/test_tokenization_luke.py
@@ -287,6 +287,131 @@ class LukeTokenizerIntegrationTests(unittest.TestCase):
             ],
         )
 
+    def test_single_text_only_entity_spans_no_padding_or_truncation(self):
+        tokenizer = LukeTokenizer.from_pretrained("studio-ousia/luke-base", return_token_type_ids=True)
+        sentence = "Top seed Ana Ivanovic said on Thursday she could hardly believe her luck."
+        spans = [(9, 21), (30, 38), (39, 42)]
+
+        encoding = tokenizer(sentence, entity_spans=spans, return_token_type_ids=True)
+
+        self.assertEqual(
+            tokenizer.decode(encoding["input_ids"], spaces_between_special_tokens=False),
+            "<s>Top seed Ana Ivanovic said on Thursday she could hardly believe her luck.</s>",
+        )
+        self.assertEqual(
+            tokenizer.decode(encoding["input_ids"][3:6], spaces_between_special_tokens=False), " Ana Ivanovic"
+        )
+        self.assertEqual(
+            tokenizer.decode(encoding["input_ids"][8:9], spaces_between_special_tokens=False), " Thursday"
+        )
+        self.assertEqual(tokenizer.decode(encoding["input_ids"][9:10], spaces_between_special_tokens=False), " she")
+
+        mask_id = tokenizer.entity_vocab["[MASK]"]
+        self.assertEqual(encoding["entity_ids"], [mask_id, mask_id, mask_id])
+        self.assertEqual(encoding["entity_attention_mask"], [1, 1, 1])
+        self.assertEqual(encoding["entity_token_type_ids"], [0, 0, 0])
+        self.assertEqual(
+            encoding["entity_position_ids"],
+            [
+                [
+                    3,
+                    4,
+                    5,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                ],
+                [
+                    8,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                ],
+                [
+                    9,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                ],
+            ],
+        )
+
     def test_single_text_padding_pytorch_tensors(self):
         tokenizer = LukeTokenizer.from_pretrained("studio-ousia/luke-base", return_token_type_ids=True)
         sentence = "Top seed Ana Ivanovic said on Thursday she could hardly believe her luck."
@@ -354,6 +479,139 @@ class LukeTokenizerIntegrationTests(unittest.TestCase):
                 tokenizer.entity_vocab["[UNK]"],
             ],
         )
+        self.assertEqual(encoding["entity_attention_mask"], [1, 1, 1])
+        self.assertEqual(encoding["entity_token_type_ids"], [0, 0, 0])
+        self.assertEqual(
+            encoding["entity_position_ids"],
+            [
+                [
+                    3,
+                    4,
+                    5,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                ],
+                [
+                    8,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                ],
+                [
+                    11,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                    -1,
+                ],
+            ],
+        )
+
+    def test_text_pair_only_entity_spans_no_padding_or_truncation(self):
+        tokenizer = LukeTokenizer.from_pretrained("studio-ousia/luke-base", return_token_type_ids=True)
+        sentence = "Top seed Ana Ivanovic said on Thursday"
+        sentence_pair = "She could hardly believe her luck."
+        spans = [(9, 21), (30, 38)]
+        spans_pair = [(0, 3)]
+
+        encoding = tokenizer(
+            sentence,
+            sentence_pair,
+            entity_spans=spans,
+            entity_spans_pair=spans_pair,
+            return_token_type_ids=True,
+        )
+
+        self.assertEqual(
+            tokenizer.decode(encoding["input_ids"], spaces_between_special_tokens=False),
+            "<s>Top seed Ana Ivanovic said on Thursday</s></s>She could hardly believe her luck.</s>",
+        )
+        self.assertEqual(
+            tokenizer.decode(encoding["input_ids"][3:6], spaces_between_special_tokens=False), " Ana Ivanovic"
+        )
+        self.assertEqual(
+            tokenizer.decode(encoding["input_ids"][8:9], spaces_between_special_tokens=False), " Thursday"
+        )
+        self.assertEqual(tokenizer.decode(encoding["input_ids"][11:12], spaces_between_special_tokens=False), "She")
+
+        mask_id = tokenizer.entity_vocab["[MASK]"]
+        self.assertEqual(encoding["entity_ids"], [mask_id, mask_id, mask_id])
         self.assertEqual(encoding["entity_attention_mask"], [1, 1, 1])
         self.assertEqual(encoding["entity_token_type_ids"], [0, 0, 0])
         self.assertEqual(


### PR DESCRIPTION
This PR contains the following fixes:
* fix tokenizer to automatically construct the entity sequence using [MASK] entity if the `entities` argument is not specified
* fix `_init_weights` function to support PyTorch 1.8
* improve docs