### PR TITLE
fix save_pretrained test

### DIFF
--- a/src/transformers/models/markuplm/tokenization_markuplm.py
+++ b/src/transformers/models/markuplm/tokenization_markuplm.py
@@ -48,6 +48,7 @@ from bs4 import BeautifulSoup
 VOCAB_FILES_NAMES = {
     "vocab_file": "vocab.json",
     "merges_file": "merges.txt",
+    "tokenizer_file": "tokenizer.json"
 }
 
 PRETRAINED_VOCAB_FILES_MAP = {


### PR DESCRIPTION
As a result, the test failed because the `tokenizer_file` key was saved in the `tokenizer_config` of the slow version. So, when we wanted to reload a tokenizer fast from what we thought was only slow files, a tokenizer fast was reloaded from the cache and we tried to add the add tokens to it anyway (but they were already there).

Nevertheless, I find this fix unnatural. I think it puts the finger on an infrequent but problematic case, and it might be beneficial to rework the general API (but probably not obvious because of Backward Compatibility)

cc @NielsRogge 