### PR TITLE
Add a test to check if the `tags_dict` is correctly saved into `tokenizer_config.json`

### DIFF
--- a/src/transformers/models/markuplm/tokenization_markuplm_fast.py
+++ b/src/transformers/models/markuplm/tokenization_markuplm_fast.py
@@ -149,7 +149,7 @@ class MarkupLMTokenizerFast(PreTrainedTokenizerFast):
         super().__init__(
             vocab_file,
             merges_file,
-            tags_dict,
+            tags_dict=tags_dict,
             tokenizer_file=tokenizer_file,
             errors=errors,
             bos_token=bos_token,

--- a/tests/test_tokenization_markuplm.py
+++ b/tests/test_tokenization_markuplm.py
@@ -18,6 +18,7 @@ import inspect
 import itertools
 import json
 import os
+import tempfile
 import unittest
 from typing import List
 
@@ -941,3 +942,38 @@ class MarkupLMTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 tokenizer_output_p = tokenizer_p.tokenize(text)
 
                 self.assertListEqual(tokenizer_output_r, tokenizer_output_p)
+
+    def test_check_tags_dict_in_tokenizer_config(self):
+        
+        def save_and_get_tags_dict(tokenizer, tmp_dir_name):
+            tokenizer.save_pretrained(tmp_dir_name)
+
+            with open(os.path.join(tmp_dir_name, "tokenizer_config.json"), encoding="utf-8") as json_file:
+                tokenizer_config = json.load(json_file)
+            
+            tags_dict_saved = tokenizer_config["tags_dict"]
+            return tags_dict_saved
+
+        tokenizers = self.get_tokenizers()
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                with tempfile.TemporaryDirectory() as tmp_dir_name:
+                    tags_dict_saved = save_and_get_tags_dict(tokenizer, tmp_dir_name)
+                    self.assertDictEqual(tags_dict_saved, self.tags_dict)
+
+        for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
+            with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
+                tokenizer_r = self.rust_tokenizer_class.from_pretrained(pretrained_name, **kwargs)
+                tokenizer_p = self.tokenizer_class.from_pretrained(pretrained_name, **kwargs)
+
+                self.assertDictEqual(tokenizer_r.tags_dict, tokenizer_p.tags_dict)
+                self.assertNotEqual(tokenizer_r.tags_dict, {})
+                self.assertNotEqual(tokenizer_r.tags_dict, None)
+
+                with tempfile.TemporaryDirectory() as tmp_dir_name:
+                    tags_dict_saved = save_and_get_tags_dict(tokenizer_p, tmp_dir_name)
+                    self.assertDictEqual(tags_dict_saved, tokenizer_r.tags_dict)
+
+                with tempfile.TemporaryDirectory() as tmp_dir_name:
+                    tags_dict_saved = save_and_get_tags_dict(tokenizer_r, tmp_dir_name)
+                    self.assertDictEqual(tags_dict_saved, tokenizer_r.tags_dict)


### PR DESCRIPTION
I propose to add :
- a new test to check if the additionnal key that we added to the tokenizer is correctly saved into `tokenizer_config.json`,
- and the fix

cc @NielsRogge 

Remaining failing tests:
```
================================================================================================================================================= short test summary info ==================================================================================================================================================
FAILED tests/test_tokenization_markuplm.py::MarkupLMTokenizationTest::test_added_tokens_do_lower_case - AssertionError: 'l' == 'l'
FAILED tests/test_tokenization_markuplm.py::MarkupLMTokenizationTest::test_maximum_encoding_length_pair_input - AssertionError: 0 not greater than 4
FAILED tests/test_tokenization_markuplm.py::MarkupLMTokenizationTest::test_maximum_encoding_length_single_input - AssertionError: 0 not greater than 4 : Issue with the testing sequence, please update it it's too short
FAILED tests/test_tokenization_markuplm.py::MarkupLMTokenizationTest::test_right_and_left_truncation - AssertionError: 0 != 3
FAILED tests/test_tokenization_markuplm.py::MarkupLMTokenizationTest::test_special_tokens_initialization - IndexError: list index out of range
FAILED tests/test_tokenization_markuplm.py::MarkupLMTokenizationTest::test_special_tokens_mask_input_pairs - AssertionError: Lists differ: [] != [19, 9, 19, 1, 8, 3, 10, 6, 19, 7, 5, 19]
FAILED tests/test_tokenization_markuplm.py::MarkupLMTokenizationTest::test_tokenize_slow_fast_equal - AssertionError: Lists differ: ['this', 'Ġis', 'Ġa', 'Ġtest'] != ['<', 'html', '><', 'h', '1', '>', 'Ġthis',[54 chars] '>']
FAILED tests/test_tokenization_markuplm.py::MarkupLMTokenizationTest::test_tokenize_special_tokens - AssertionError: 0 != 1
============================================================================================================================= 8 failed, 64 passed, 7 skipped, 6 warnings in 114.83s (0:01:54) ==============================================================================================================================
```