### PR TITLE
set `add_prefix_token` to true by default

### DIFF
--- a/src/transformers/models/layoutlmv3/tokenization_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/tokenization_layoutlmv3.py
@@ -517,7 +517,13 @@ class LayoutLMv3Tokenizer(PreTrainedTokenizer):
 
     def prepare_for_tokenization(self, text, is_split_into_words=False, **kwargs):
         add_prefix_space = kwargs.pop("add_prefix_space", self.add_prefix_space)
-        if (is_split_into_words or add_prefix_space) and (len(text) > 0 and not text[0].isspace()):
+        # If the text starts with a token that should not be split, no space is added before the text in any case.
+        # It's necessary to match the fast tokenization
+        if (
+            (is_split_into_words or add_prefix_space)
+            and (len(text) > 0 and not text[0].isspace())
+            and sum([text.startswith(no_split_token) for no_split_token in self.unique_no_split_tokens]) == 0
+        ):
             text = " " + text
         return (text, kwargs)
 

--- a/src/transformers/models/layoutlmv3/tokenization_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/tokenization_layoutlmv3.py
@@ -283,7 +283,7 @@ class LayoutLMv3Tokenizer(PreTrainedTokenizer):
         unk_token="<unk>",
         pad_token="<pad>",
         mask_token="<mask>",
-        add_prefix_space=False,
+        add_prefix_space=True,
         cls_token_box=[0, 0, 0, 0],
         sep_token_box=[1000, 1000, 1000, 1000],
         pad_token_box=[0, 0, 0, 0],

--- a/src/transformers/models/layoutlmv3/tokenization_layoutlmv3_fast.py
+++ b/src/transformers/models/layoutlmv3/tokenization_layoutlmv3_fast.py
@@ -152,7 +152,7 @@ class LayoutLMv3TokenizerFast(PreTrainedTokenizerFast):
         unk_token="<unk>",
         pad_token="<pad>",
         mask_token="<mask>",
-        add_prefix_space=False,
+        add_prefix_space=True,
         trim_offsets=True,
         cls_token_box=[0, 0, 0, 0],
         sep_token_box=[1000, 1000, 1000, 1000],

--- a/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
@@ -130,7 +130,7 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertListEqual(tokens, bpe_tokens)
 
         input_tokens = tokens + [tokenizer.unk_token]
-        input_bpe_tokens = [0, 1, 2, 15, 10, 9, 3, 2, 15, 19]
+        input_bpe_tokens = [14, 15, 10, 9, 3, 2, 15, 19]
         self.assertListEqual(tokenizer.convert_tokens_to_ids(input_tokens), input_bpe_tokens)
 
     @slow

--- a/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
@@ -35,7 +35,8 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = LayoutLMv3Tokenizer
     rust_tokenizer_class = LayoutLMv3TokenizerFast
     test_rust_tokenizer = True
-    space_between_special_tokens = True
+    # determined by the tokenization algortihm and the way it's decoded by the fast tokenizers
+    space_between_special_tokens = False
     test_seq2seq = False
     from_pretrained_kwargs = {"cls_token": "<s>"}
 
@@ -124,7 +125,7 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_full_tokenizer(self):
         tokenizer = self.tokenizer_class(self.vocab_file, self.merges_file, **self.special_tokens_map)
         text = "lower newer"
-        bpe_tokens = ["l", "o", "w", "er", "\u0120", "n", "e", "w", "er"]
+        bpe_tokens = ['Ġlow', 'er', 'Ġ', 'n', 'e', 'w', 'er']
         tokens = tokenizer.tokenize(text)  # , add_prefix_space=True)
         self.assertListEqual(tokens, bpe_tokens)
 
@@ -367,7 +368,7 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 text_2 = tokenizer.decode(ids)
                 self.assertIsInstance(text_2, str)
 
-                output_text = "lowernewer"
+                output_text = " lower newer"
                 self.assertEqual(text_2, output_text)
 
     def test_mask_output(self):

--- a/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
@@ -1417,7 +1417,7 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         inputs = new_tokenizer(text, boxes=boxes)
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        expected_result = "this is the"
+        expected_result = " this is the"
 
         if tokenizer.backend_tokenizer.normalizer is not None:
             expected_result = tokenizer.backend_tokenizer.normalizer.normalize_str(expected_result)
@@ -1535,7 +1535,7 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         inputs = new_tokenizer(words, boxes=boxes)
         self.assertEqual(len(inputs["input_ids"]), 2)
         decoded_input = new_tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-        expected_result = "this is"
+        expected_result = " this is"
 
         if tokenizer.backend_tokenizer.normalizer is not None:
             expected_result = tokenizer.backend_tokenizer.normalizer.normalize_str(expected_result)

--- a/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_tokenization_layoutlmv3.py
@@ -1616,7 +1616,8 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                     returned_tensor = "jax"
 
                 # Single example
-                words, boxes = self.get_words_and_boxes()
+                words = ["HuggingFace", "is", "solving", "NLP", "one", "commit", "at", "a", "time"]
+                boxes = [[i,i,i,i] for i in range(len(words))]
                 tokens = tokenizer.encode_plus(
                     words,
                     boxes=boxes,
@@ -1635,10 +1636,14 @@ class LayoutLMv3TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
                 # Batch of examples
                 # For these 2 examples, 3 training examples will be created
-                words, boxes = self.get_words_and_boxes_batch()
+                words_batched = [
+                    ["HuggingFace", "is", "solving", "NLP", "one", "commit", "at", "a", "time"],
+                    ["Very", "tiny", "input"]
+                ]
+                boxes_batched = [[[i,i,i,i] for i in range(len(words_item))] for words_item in words_batched]
                 tokens = tokenizer.batch_encode_plus(
-                    words,
-                    boxes=boxes,
+                    words_batched,
+                    boxes=boxes_batched,
                     max_length=6,
                     padding=True,
                     truncation="only_first",


### PR DESCRIPTION
# What does this PR do?

This PR shows the changes needed to set the default behaviour to `add_prefix_space` to `True`. I think this should be the default behaviour as 1) it is what is proposed in the authors' code and 2) it is the most logical for decoding. 

I even wonder if we shouldn't just support this behaviour (`add_prefix_space`=`True`)

Locally I only have one test (not slow) that doesn't pass - `test_batch_encode_dynamic_overflowing` - which was already failing [before](https://app.circleci.com/pipelines/github/huggingface/transformers/39226/workflows/9e2943f6-8cf8-4a3f-86da-f74fb218e52a/jobs/439608).

Let me know what you think :blush: 