### PR TITLE
Use Mask2Former ignore_value in mask matching and losses

### DIFF
--- a/tests/models/mask2former/test_modeling_mask2former.py
+++ b/tests/models/mask2former/test_modeling_mask2former.py
@@ -263,6 +263,29 @@ class Mask2FormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
         outputs = model(**inputs)
         self.assertTrue(outputs.loss is not None)
 
+    def test_loss_ignores_ignore_value_pixels(self):
+        from transformers.models.mask2former.modeling_mask2former import Mask2FormerLoss
+
+        config = self.model_tester.get_config()
+        config.ignore_value = 255
+        loss_module = Mask2FormerLoss(
+            config=config,
+            weight_dict={"loss_cross_entropy": 1.0, "loss_mask": 1.0, "loss_dice": 1.0},
+        ).to(torch_device)
+
+        masks_queries_logits = torch.zeros((1, 2, 2, 2), device=torch_device)
+        indices = [(torch.tensor([0]), torch.tensor([0]))]
+
+        target_mask = torch.tensor([[[1.0, 255.0], [0.0, 1.0]]], device=torch_device)
+        losses = loss_module.loss_masks(masks_queries_logits, [target_mask], indices, num_masks=1)
+
+        masks_queries_logits_changed = masks_queries_logits.clone()
+        masks_queries_logits_changed[0, 0, 0, 1] = 1000
+        losses_changed = loss_module.loss_masks(masks_queries_logits_changed, [target_mask], indices, num_masks=1)
+
+        self.assertTrue(torch.allclose(losses["loss_mask"], losses_changed["loss_mask"]))
+        self.assertTrue(torch.allclose(losses["loss_dice"], losses_changed["loss_dice"]))
+
     def test_hidden_states_output(self):
         config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
         self.model_tester.create_and_check_mask2former_model(config, **inputs, output_hidden_states=True)


### PR DESCRIPTION
### Motivation
- `Mask2FormerConfig.ignore_value` was defined but never used, causing ignored pixels from original checkpoints to contribute to matching costs and training losses. 
- The change ensures ignored target pixels are excluded from both Hungarian matching and mask/dice loss computations to preserve backward compatibility and correct training behavior.

### Description
- Wire `config.ignore_value` into `Mask2FormerLoss` and `Mask2FormerHungarianMatcher` so the model-level ignore value is available where matching and losses are computed. 
- Extend `dice_loss`, `sigmoid_cross_entropy_loss`, `pair_wise_dice_loss`, and `pair_wise_sigmoid_cross_entropy_loss` to accept a `valid_labels` mask and to exclude ignored points from numerators/denominators. 
- Mask out sampled target points equal to `ignore_value` when computing pairwise matching costs and when sampling points for the pointwise mask losses. 
- Add a regression test `test_loss_ignores_ignore_value_pixels` in `tests/models/mask2former/test_modeling_mask2former.py` that verifies changing logits at an ignored pixel does not change `loss_mask` or `loss_dice`.

### Testing
- Ran lint/format checks with `python -m ruff check src/transformers/models/mask2former/modeling_mask2former.py tests/models/mask2former/test_modeling_mask2former.py` and `python -m ruff format ...`, both succeeded. 
- Verified file import/compile sanity with `python -m compileall src/transformers/models/mask2former/modeling_mask2former.py tests/models/mask2former/test_modeling_mask2former.py`, which succeeded. 
- Attempted targeted unit test with `python -m pytest tests/models/mask2former/test_modeling_mask2former.py -k ignore_value -q`, but test collection failed in this environment because PyTorch is not installed; the added regression test should pass in CI where PyTorch is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a54c62fee88336aa93cf0d96119ef5)